### PR TITLE
Fix for broken RoundRobin?

### DIFF
--- a/core/smpp-extensions/src/main/java/org/restcomm/smpp/EsmeManagement.java
+++ b/core/smpp-extensions/src/main/java/org/restcomm/smpp/EsmeManagement.java
@@ -159,14 +159,14 @@ public class EsmeManagement implements EsmeManagementMBean {
 	}
 
 	@Override
-	public Esme getEsmeByClusterName(String esmeClusterName) {
-		EsmeCluster esmeCluster = this.esmeClusters.get(esmeClusterName);
+	public Esme getEsmeByClusterName(final String esmeClusterName, final boolean anIndexUpdate) {
+		final EsmeCluster esmeCluster = this.esmeClusters.get(esmeClusterName);
 		if (esmeCluster != null) {
-			return esmeCluster.getNextEsme();
+			return esmeCluster.getNextEsme(anIndexUpdate);
 		}
 		return null;
 	}
-
+	
 	protected Esme getEsmeByPrimaryKey(String SystemId, String host, int port, SmppBindType smppBindType) {
 
 		// Check for actual SystemId, host and port

--- a/core/smpp-extensions/src/main/java/org/restcomm/smpp/EsmeManagementMBean.java
+++ b/core/smpp-extensions/src/main/java/org/restcomm/smpp/EsmeManagementMBean.java
@@ -35,7 +35,7 @@ public interface EsmeManagementMBean {
 
 	Esme getEsmeByName(String esmeName);
 
-	Esme getEsmeByClusterName(String esmeClusterName);
+	Esme getEsmeByClusterName(String esmeClusterName, boolean anIndexUpdate);
 
     Esme createEsme(String name, String systemId, String password, String host, int port, boolean chargingEnabled,
             String smppBindType, String systemType, String smppIntVersion, byte ton, byte npi, String address,


### PR DESCRIPTION
Hi,

I've noticed that in case of 2 ESMEs in ta cluster, messages were sent only through the 'first' one.

Please consider the proposed  changes (together with corresponding changes in SMSCGW core).

Regards,
adam